### PR TITLE
Raw response in Attribute values

### DIFF
--- a/examples/macro/src/main.rs
+++ b/examples/macro/src/main.rs
@@ -1,14 +1,19 @@
 use mikrotik_rs::{command, protocol::command::CommandBuilder};
 
 fn main() {
-    let macro_command = command!("/some/random/command", attribute1="1", attribute2, attribute3="2");
+    let macro_command = command!(
+        "/some/random/command",
+        attribute1 = "1",
+        attribute2,
+        attribute3 = "2"
+    );
 
     let tag = macro_command.tag;
 
     let builder_command = CommandBuilder::with_tag(tag)
         .command("/some/random/command")
-        .attribute("attribute1",Some("1"))
-        .attribute("attribute2",Some("2"))
+        .attribute("attribute1", Some("1"))
+        .attribute("attribute2", Some("2"))
         .build();
 
     assert_eq!(macro_command.data, builder_command.data);

--- a/mikrotik-rs/src/lib.rs
+++ b/mikrotik-rs/src/lib.rs
@@ -58,9 +58,9 @@ mod actor;
 mod device;
 /// Error module for handling errors during device operations.
 pub mod error;
-/// Protocol module for handling MikroTik API communication.
-pub mod protocol;
 /// Macros module to make your life easier.
 pub mod macros;
+/// Protocol module for handling MikroTik API communication.
+pub mod protocol;
 
 pub use device::MikrotikDevice;

--- a/mikrotik-rs/src/macros.rs
+++ b/mikrotik-rs/src/macros.rs
@@ -91,7 +91,6 @@ macro_rules! command {
     (@opt) => { None };
 }
 
-
 #[cfg(test)]
 mod test {
     /// Helper to parse the RouterOS length-prefixed “words” out of the command data.
@@ -116,7 +115,7 @@ mod test {
             if i + len > data.len() {
                 panic!("Malformed command data: length prefix exceeds available data.");
             }
-            let word = &data[i..i+len];
+            let word = &data[i..i + len];
             i += len;
             // Convert to String for easier assertions
             words.push(String::from_utf8_lossy(word).to_string());
@@ -134,7 +133,10 @@ mod test {
 
         // Word[1] => .tag=xxxx
         // We can’t check the exact tag value because it's random, but we can ensure it starts with ".tag="
-        assert!(words[1].starts_with(".tag="), "Tag word should start with .tag=");
+        assert!(
+            words[1].starts_with(".tag="),
+            "Tag word should start with .tag="
+        );
 
         // Should only have these two words (plus the 0-length terminator, which we skip).
         assert_eq!(words.len(), 2, "Expected two words (command + .tag=).");
@@ -142,11 +144,14 @@ mod test {
 
     #[test]
     fn test_command_with_one_attribute() {
-        let cmd = command!("/interface/ethernet/print", user="admin");
+        let cmd = command!("/interface/ethernet/print", user = "admin");
         let words = parse_words(&cmd.data);
 
         assert_eq!(words[0], "/interface/ethernet/print");
-        assert!(words[1].starts_with(".tag="), "Expected .tag= as second word");
+        assert!(
+            words[1].starts_with(".tag="),
+            "Expected .tag= as second word"
+        );
         // Word[2] => "=user=admin"
         assert_eq!(words[2], "=user=admin");
         // So total 3 words plus 0-terminator
@@ -155,7 +160,7 @@ mod test {
 
     #[test]
     fn test_command_with_multiple_attributes() {
-        let cmd = command!("/some/random", attribute_no_value, another="value");
+        let cmd = command!("/some/random", attribute_no_value, another = "value");
         let words = parse_words(&cmd.data);
 
         // Word[0] => "/some/random"

--- a/mikrotik-rs/src/protocol/command.rs
+++ b/mikrotik-rs/src/protocol/command.rs
@@ -163,6 +163,37 @@ impl CommandBuilder<Cmd> {
         }
     }
 
+    /// Adds an attribute with a raw byte value to the command being built.
+    ///
+    /// Use this method when your attribute values might contain non-UTF-8 or binary data.
+    /// For regular string values, [`CommandBuilder<Cmd>::attribute`] provides a more convenient interface.
+    ///
+    /// # Arguments
+    ///
+    /// * `key` - The attribute's key (must be valid UTF-8).
+    /// * `value` - The attribute's value as raw bytes, which is optional. If `None`, the attribute is treated as a flag.
+    ///
+    /// # Returns
+    ///
+    /// The builder with the attribute added, allowing for method chaining.
+    pub fn attribute_raw(self, key: &str, value: Option<&[u8]>) -> Self {
+        let Self { tag, mut cmd, .. } = self;
+        match value {
+            Some(v) => {
+                let command = [b"=", key.as_bytes(), b"=", v].concat();
+                cmd.write_word(&command);
+            }
+            None => {
+                cmd.write_word(format!("={key}=").as_bytes());
+            }
+        };
+        CommandBuilder {
+            tag,
+            cmd,
+            state: PhantomData,
+        }
+    }
+
     /// Adds a query to the command being built.
     /// pushes 'true' if an item has a value of property name, 'false' if it does not.
     ///
@@ -333,6 +364,7 @@ pub enum QueryOperator {
     /// Represents the `.` operator.
     Dot,
 }
+
 impl QueryOperator {
     #[inline]
     fn code(self) -> char {

--- a/mikrotik-rs/src/protocol/command.rs
+++ b/mikrotik-rs/src/protocol/command.rs
@@ -242,7 +242,7 @@ impl CommandBuilder<Cmd> {
     ///
     /// The builder with the attribute added, allowing for method chaining.
     pub fn query_operations(mut self, operations: impl Iterator<Item = QueryOperator>) -> Self {
-        let query:String = "?#".chars().chain(operations.map(|op| op.code())).collect();
+        let query: String = "?#".chars().chain(operations.map(|op| op.code())).collect();
         self.cmd.write_word(query.as_bytes());
         self
     }


### PR DESCRIPTION
Sometimes attributes responses are not valid UTF-8. Instead of returning an error, add another field to let the user handle the packet

Partial fix for #22 