### PR TITLE
Fix panic on connection loss

### DIFF
--- a/examples/check-update/src/main.rs
+++ b/examples/check-update/src/main.rs
@@ -1,18 +1,18 @@
 use mikrotik_rs::{protocol::command::CommandBuilder, MikrotikDevice};
 
 #[tokio::main]
-async fn main() {
-    let device = MikrotikDevice::connect("192.168.122.144:8728", "admin", Some("admin"))
-        .await
-        .unwrap();
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let device = MikrotikDevice::connect("192.168.122.144:8728", "admin", Some("admin")).await?;
 
     let check_updates = CommandBuilder::new()
         .command("/system/package/update/install")
         .build();
 
-    let mut update_responses = device.send_command(check_updates).await;
+    let mut update_responses = device.send_command(check_updates).await?;
 
     while let Some(res) = update_responses.recv().await {
         println!(">> Get System Res Response {:?}", res);
     }
+
+    Ok(())
 }

--- a/examples/network-monitor/src/main.rs
+++ b/examples/network-monitor/src/main.rs
@@ -1,19 +1,19 @@
 use mikrotik_rs::{protocol::command::CommandBuilder, MikrotikDevice};
 
 #[tokio::main]
-async fn main() {
-    let device = MikrotikDevice::connect("192.168.122.144:8728", "admin", Some("admin"))
-        .await
-        .unwrap();
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let device = MikrotikDevice::connect("192.168.122.144:8728", "admin", Some("admin")).await?;
 
     let monitor_cmd = CommandBuilder::new()
         .command("/interface/monitor-traffic")
         .attribute("interface", Some("ether1"))
         .build();
 
-    let mut monitor_responses = device.send_command(monitor_cmd).await;
+    let mut monitor_responses = device.send_command(monitor_cmd).await?;
 
     while let Some(res) = monitor_responses.recv().await {
         println!(">> Get System Res Response {:?}", res);
     }
+
+    Ok(())
 }

--- a/examples/system-resource/src/main.rs
+++ b/examples/system-resource/src/main.rs
@@ -2,10 +2,8 @@ use mikrotik_rs::{protocol::command::CommandBuilder, MikrotikDevice};
 
 // Using the current_thread flavor because multiple threads are not needed for this example
 #[tokio::main]
-async fn main() {
-    let device = MikrotikDevice::connect("192.168.122.144:8728", "admin", Some("admin"))
-        .await
-        .unwrap();
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let device = MikrotikDevice::connect("192.168.122.144:8728", "admin", Some("admin")).await?;
 
     let get_system_res = CommandBuilder::new()
         .command("/system/resource/print")
@@ -13,9 +11,11 @@ async fn main() {
         .attribute("interval", Some("1"))
         .build();
 
-    let mut users_stream = device.send_command(get_system_res).await;
+    let mut users_stream = device.send_command(get_system_res).await?;
 
     while let Some(res) = users_stream.recv().await {
         println!(">> Get System Res Response {:?}", res);
     }
+
+    Ok(())
 }

--- a/examples/users/src/main.rs
+++ b/examples/users/src/main.rs
@@ -2,16 +2,16 @@ use mikrotik_rs::{protocol::command::CommandBuilder, MikrotikDevice};
 
 // Using the current_thread flavor because multiple threads are not needed for this example
 #[tokio::main]
-async fn main() {
-    let device = MikrotikDevice::connect("192.168.100.149:8728", "admin", Some("admin"))
-        .await
-        .unwrap();
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let device = MikrotikDevice::connect("192.168.100.149:8728", "admin", Some("admin")).await?;
 
     let get_users_cmd = CommandBuilder::new().command("/user/active/print").build();
 
-    let mut users_stream = device.send_command(get_users_cmd).await;
+    let mut users_stream = device.send_command(get_users_cmd).await?;
 
     while let Some(interface) = users_stream.recv().await {
         println!(">> Get Users Response {:?}", interface);
     }
+
+    Ok(())
 }

--- a/mikrotik-rs/src/actor.rs
+++ b/mikrotik-rs/src/actor.rs
@@ -5,10 +5,10 @@ use tokio::net::{TcpStream, ToSocketAddrs};
 use tokio::sync::mpsc::{self, Sender};
 
 use crate::error::{DeviceError, DeviceResult};
+use crate::protocol::CommandResponse;
 use crate::protocol::command::CommandBuilder;
 use crate::protocol::sentence::Sentence;
 use crate::protocol::word::WordCategory;
-use crate::protocol::CommandResponse;
 
 /// Command message with data to write to the device
 pub struct ReadActorMessage {

--- a/mikrotik-rs/src/error.rs
+++ b/mikrotik-rs/src/error.rs
@@ -1,9 +1,9 @@
 use std::fmt;
 use std::io;
 
-use crate::protocol::word::WordCategory;
 use crate::protocol::CommandResponse;
 use crate::protocol::TrapResponse;
+use crate::protocol::word::WordCategory;
 
 /// Result type alias for MikroTik device operations
 pub type DeviceResult<T> = Result<T, DeviceError>;

--- a/mikrotik-rs/src/lib.rs
+++ b/mikrotik-rs/src/lib.rs
@@ -29,9 +29,9 @@
 //!     let mut client = MikrotikDevice::connect(addr, username, Some(password)).await?;
 //!
 //!     let command = CommandBuilder::new().command("/interface/print").build(); // Example command
-//!     let response_channel = client.send_command(command).await?;
+//!     let mut response_channel = client.send_command(command).await?;
 //!     while let Some(response) = response_channel.recv().await {
-//!        println!("{:?}", response);
+//!        println!("{:?}", response?);
 //!     }
 //! }
 //! ```

--- a/mikrotik-rs/src/protocol/command.rs
+++ b/mikrotik-rs/src/protocol/command.rs
@@ -438,12 +438,16 @@ mod tests {
         let command = CommandBuilder::<NoCmd>::login("admin", Some("password"));
 
         assert!(str::from_utf8(&command.data).unwrap().contains("/login"));
-        assert!(str::from_utf8(&command.data)
-            .unwrap()
-            .contains("name=admin"));
-        assert!(str::from_utf8(&command.data)
-            .unwrap()
-            .contains("password=password"));
+        assert!(
+            str::from_utf8(&command.data)
+                .unwrap()
+                .contains("name=admin")
+        );
+        assert!(
+            str::from_utf8(&command.data)
+                .unwrap()
+                .contains("password=password")
+        );
     }
 
     #[test]

--- a/mikrotik-rs/src/protocol/error.rs
+++ b/mikrotik-rs/src/protocol/error.rs
@@ -1,4 +1,4 @@
-use super::{sentence::SentenceError, word::Word, TrapCategoryError};
+use super::{TrapCategoryError, sentence::SentenceError, word::Word};
 
 /// Possible errors while parsing a [`CommandResponse`] from a [`Sentence`].
 ///


### PR DESCRIPTION
## Summary

This PR fixes a critical panic that occurred when the router reboots or closes the TCP connection. Previously, `MikrotikDevice::send_command` would panic with `expect("msg send failed")` when trying to send commands after the connection was lost.

## Changes

- Changed `send_command` return type from `mpsc::Receiver<...>` to `DeviceResult<mpsc::Receiver<...>>`
- Replaced `.expect()` with `?` operator to properly handle connection loss
- Updated documentation to remove `# Panics` section and add `# Errors` section
- Updated all examples to handle the new `Result` return type

## Breaking Changes

This is a **breaking change** - the return type of `send_command` has changed. Callers must now handle the `Result` (e.g., use `?` or match on it).

## Testing

- All examples compile and run successfully
- Connection loss scenarios now return `DeviceError::Channel` instead of panicking
- Normal operation remains unchanged

Fixes the panic issue when router reboots or connection is lost.