### PR TITLE
Add `std` feature flag

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -53,30 +53,23 @@ jobs:
               run: cargo test --workspace
 
     test-features:
-        name: 🧪 Test feature combinations
+        name: 🧪 Feature combinations
         runs-on: ubuntu-latest
-        strategy:
-            fail-fast: false
-            matrix:
-                include:
-                    - name: "mikrotik-proto (no_std)"
-                      cmd: cargo test -p mikrotik-proto --no-default-features
-                    - name: "mikrotik-proto (std)"
-                      cmd: cargo test -p mikrotik-proto --features std
-                    - name: "mikrotik-rs (no runtime, no std)"
-                      cmd: cargo check -p mikrotik-rs --no-default-features
-                    - name: "mikrotik-rs (embassy, no std)"
-                      cmd: cargo check -p mikrotik-rs --no-default-features --features embassy
-                    - name: "mikrotik-rs (tokio, no std)"
-                      cmd: cargo check -p mikrotik-rs --no-default-features --features tokio
-                    - name: "mikrotik-rs (std only, no runtime)"
-                      cmd: cargo check -p mikrotik-rs --no-default-features --features std
         steps:
             - name: 🛒 Checkout
               uses: actions/checkout@v6
 
-            - name: 🧪 ${{ matrix.name }}
-              run: ${{ matrix.cmd }}
+            - name: 📦 Install cargo-hack
+              uses: taiki-e/install-action@cargo-hack
+
+            - name: 🔍 Check each feature independently
+              run: cargo hack check --each-feature --no-dev-deps --workspace --ignore-private
+
+            - name: 🔍 Check feature powerset (facade)
+              run: cargo hack check --feature-powerset --depth 2 --no-dev-deps -p mikrotik-rs
+
+            - name: 🧪 Test no_std path
+              run: cargo test -p mikrotik-proto --no-default-features
 
     doc:
         name: 📖 Doc

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -49,8 +49,34 @@ jobs:
             - name: 🛒 Checkout
               uses: actions/checkout@v6
 
-            - name: 🧪 Test
+            - name: 🧪 Test (default features)
               run: cargo test --workspace
+
+    test-features:
+        name: 🧪 Test feature combinations
+        runs-on: ubuntu-latest
+        strategy:
+            fail-fast: false
+            matrix:
+                include:
+                    - name: "mikrotik-proto (no_std)"
+                      cmd: cargo test -p mikrotik-proto --no-default-features
+                    - name: "mikrotik-proto (std)"
+                      cmd: cargo test -p mikrotik-proto --features std
+                    - name: "mikrotik-rs (no runtime, no std)"
+                      cmd: cargo check -p mikrotik-rs --no-default-features
+                    - name: "mikrotik-rs (embassy, no std)"
+                      cmd: cargo check -p mikrotik-rs --no-default-features --features embassy
+                    - name: "mikrotik-rs (tokio, no std)"
+                      cmd: cargo check -p mikrotik-rs --no-default-features --features tokio
+                    - name: "mikrotik-rs (std only, no runtime)"
+                      cmd: cargo check -p mikrotik-rs --no-default-features --features std
+        steps:
+            - name: 🛒 Checkout
+              uses: actions/checkout@v6
+
+            - name: 🧪 ${{ matrix.name }}
+              run: ${{ matrix.cmd }}
 
     doc:
         name: 📖 Doc

--- a/mikrotik-proto/Cargo.toml
+++ b/mikrotik-proto/Cargo.toml
@@ -9,6 +9,9 @@ repository.workspace = true
 
 [lib]
 
+[features]
+std = []
+
 [dependencies]
 thiserror = { workspace = true }
 uuid = { workspace = true }

--- a/mikrotik-proto/src/connection.rs
+++ b/mikrotik-proto/src/connection.rs
@@ -42,13 +42,13 @@ use alloc::collections::VecDeque;
 use alloc::string::String;
 use alloc::vec::Vec;
 
+use crate::HashMap;
 use crate::codec::{self, Decode};
 use crate::command::{Command, CommandBuilder};
 use crate::error::ConnectionError;
 use crate::response::{CommandResponse, ReplyResponse, TrapResponse};
 use crate::tag::Tag;
 use crate::word::Word;
-use hashbrown::HashMap;
 
 /// Application-facing events produced by the connection state machine.
 ///

--- a/mikrotik-proto/src/lib.rs
+++ b/mikrotik-proto/src/lib.rs
@@ -1,4 +1,4 @@
-#![no_std]
+#![cfg_attr(not(feature = "std"), no_std)]
 #![warn(missing_docs)]
 //! # mikrotik-proto
 //!
@@ -16,6 +16,12 @@
 //! This crate performs **no I/O**. It accepts byte slices as input and produces
 //! byte buffers and events as output. A runtime adapter (e.g., `mikrotik-tokio`)
 //! is responsible for actual network communication.
+//!
+//! # Feature flags
+//!
+//! | Feature | Default | Description |
+//! |---------|---------|-------------|
+//! | `std`   | no      | Uses `std::collections::HashMap` in public types. When disabled (default), falls back to `hashbrown::HashMap` for `no_std` compatibility. |
 //!
 //! # Architecture
 //!
@@ -40,6 +46,16 @@
 //! ```
 
 extern crate alloc;
+
+// Re-export the appropriate HashMap type based on feature flags.
+//
+// When the `std` feature is enabled (default), public types use
+// `std::collections::HashMap`. When disabled (for `no_std` environments),
+// they fall back to `hashbrown::HashMap`.
+#[cfg(not(feature = "std"))]
+pub use hashbrown::HashMap;
+#[cfg(feature = "std")]
+pub use std::collections::HashMap;
 
 /// Wire-format codec for MikroTik API length-prefixed words and sentences.
 pub mod codec;

--- a/mikrotik-proto/src/response.rs
+++ b/mikrotik-proto/src/response.rs
@@ -12,7 +12,7 @@ use alloc::string::String;
 use alloc::vec::Vec;
 use core::fmt::{self, Display, Formatter};
 
-use hashbrown::HashMap;
+use crate::HashMap;
 
 use crate::codec::RawSentence;
 use crate::error::{MissingWord, ProtocolError, TrapCategoryError, WordType};

--- a/mikrotik-rs/Cargo.toml
+++ b/mikrotik-rs/Cargo.toml
@@ -18,7 +18,8 @@ doctest = false
 workspace = true
 
 [features]
-default = ["tokio"]
+default = ["tokio", "std"]
+std = ["mikrotik-proto/std"]
 tokio = ["dep:mikrotik-tokio"]
 embassy = ["dep:mikrotik-embassy"]
 tokio-tls = ["mikrotik-tokio?/tokio-tls"]

--- a/mikrotik-rs/src/lib.rs
+++ b/mikrotik-rs/src/lib.rs
@@ -14,6 +14,7 @@
 //!
 //! | Feature     | Default | Description |
 //! |-------------|---------|-------------|
+//! | `std`       | **yes** | Uses `std::collections::HashMap` in public response types. Disable for `no_std` (falls back to `hashbrown::HashMap`). |
 //! | `tokio`     | **yes** | Enables the Tokio async adapter and [`MikrotikDevice`] client |
 //! | `embassy`   | no      | Enables the Embassy embedded async adapter and `run` function |
 //! | `tokio-tls` | no      | Enables TLS support via `tokio-rustls` (bring your own crypto provider) |
@@ -84,6 +85,7 @@ compile_error!("This library supports 32-bit architectures or higher.");
 pub use mikrotik_proto as proto;
 
 // Re-export key protocol types at crate root
+pub use mikrotik_proto::HashMap;
 pub use mikrotik_proto::command::{Command, CommandBuilder, QueryOperator};
 pub use mikrotik_proto::connection::{Connection, Event, State, Transmit};
 pub use mikrotik_proto::error::{ConnectionError, LoginError, ProtocolError};

--- a/mikrotik-tokio/Cargo.toml
+++ b/mikrotik-tokio/Cargo.toml
@@ -14,7 +14,7 @@ doctest = false
 tokio-tls = ["dep:tokio-rustls", "dep:rustls"]
 
 [dependencies]
-mikrotik-proto = { workspace = true }
+mikrotik-proto = { workspace = true, features = ["std"] }
 tokio = { workspace = true, features = ["net", "sync", "rt", "macros", "io-util"] }
 thiserror = { workspace = true }
 tokio-rustls = { version = "0.26", default-features = false, features = ["tls12"], optional = true }


### PR DESCRIPTION
In `std` environment we want to use `std::HashMap` instead of the `hashbrown` one.

Close #44 