### PR TITLE
chore: prepare for 0.8.0 release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,38 +5,51 @@ on:
     tags:
       - 'v*.*.*'
 
+env:
+  CARGO_TERM_COLOR: always
+
 jobs:
   preflight:
-    name: 🛡️ Preflight
+    name: Preflight
     runs-on: ubuntu-latest
     steps:
-      - name: 🛒 Checkout
+      - name: Checkout
         uses: actions/checkout@v6
 
-      - name: 📎 Clippy
+      - name: Format
+        run: cargo fmt --all -- --check
+
+      - name: Clippy
         run: cargo clippy --workspace --all-targets -- -D warnings
 
-      - name: 🧪 Test
+      - name: Test
         run: cargo test --workspace
 
-  publish-and-release:
-    name: 🚀 Publish and Release
+  publish:
+    name: Publish
     runs-on: ubuntu-latest
     needs: preflight
-    permissions:
-      contents: write
-      packages: write
     steps:
-      - name: 🛒 Checkout
+      - name: Checkout
         uses: actions/checkout@v6
 
-      - name: 📦 Publish all crates to crates.io
+      - name: Publish all crates to crates.io
         run: cargo publish --workspace --token ${{ secrets.CRATES_IO_TOKEN }}
 
-      - name: 📢 Create GitHub Release
+  release:
+    name: GitHub Release
+    runs-on: ubuntu-latest
+    needs: publish
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Create GitHub Release
         uses: softprops/action-gh-release@v3
         with:
-          name: Release ${{ github.ref }}
+          name: ${{ github.ref_name }}
           draft: false
           prerelease: false
           generate_release_notes: true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,9 +18,9 @@ uuid = { version = "1", default-features = false, features = ["v4"] }
 hashbrown = "0.17"
 
 # Internal crates
-mikrotik-proto = { version = "0.1.0", path = "mikrotik-proto" }
-mikrotik-tokio = { version = "0.1.0", path = "mikrotik-tokio" }
-mikrotik-embassy = { version = "0.1.0", path = "mikrotik-embassy" }
+mikrotik-proto = { version = "0.2.0", path = "mikrotik-proto" }
+mikrotik-tokio = { version = "0.2.0", path = "mikrotik-tokio" }
+mikrotik-embassy = { version = "0.1.1", path = "mikrotik-embassy" }
 
 [workspace.lints.rust]
 unsafe_code = "forbid"

--- a/mikrotik-embassy/Cargo.toml
+++ b/mikrotik-embassy/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "mikrotik-embassy"
 description = "Embassy async embedded client for MikroTik RouterOS API"
-version = "0.1.0"
+version = "0.1.1"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true

--- a/mikrotik-proto/Cargo.toml
+++ b/mikrotik-proto/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "mikrotik-proto"
 description = "Sans-IO protocol implementation for MikroTik RouterOS API"
-version = "0.1.0"
+version = "0.2.0"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true

--- a/mikrotik-rs/Cargo.toml
+++ b/mikrotik-rs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mikrotik-rs"
-version = "0.7.0"
+version = "0.8.0"
 description = "Asynchronous Rust library for interfacing with MikroTik routers"
 edition.workspace = true
 authors.workspace = true

--- a/mikrotik-tokio/Cargo.toml
+++ b/mikrotik-tokio/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "mikrotik-tokio"
 description = "Tokio-based async client for MikroTik RouterOS API"
-version = "0.1.0"
+version = "0.2.0"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true


### PR DESCRIPTION
Bump all workspace crates for the v0.8.0 release:
- mikrotik-proto: 0.1.0 → 0.2.0
- mikrotik-tokio: 0.1.0 → 0.2.0
- mikrotik-embassy: 0.1.0 → 0.1.1
- mikrotik-rs: 0.7.0 → 0.8.0
