### PR TITLE
fix(tokio)!: prevent response loss under burst traffic

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,10 +20,10 @@ jobs:
         run: cargo fmt --all -- --check
 
       - name: Clippy
-        run: cargo clippy --workspace --all-targets -- -D warnings
+        run: cargo clippy --workspace --all-targets --all-features -- -D warnings
 
       - name: Test
-        run: cargo test --workspace
+        run: cargo test --workspace --all-features
 
   publish:
     name: Publish
@@ -33,8 +33,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
-      - name: Publish all crates to crates.io
-        run: cargo publish --workspace --token ${{ secrets.CRATES_IO_TOKEN }}
+      - name: Publish Tokio transport to crates.io
+        run: cargo publish -p oxidns-mikrotik-tokio --token ${{ secrets.CRATES_IO_TOKEN }}
+
+      - name: Publish facade to crates.io
+        run: cargo publish -p oxidns-mikrotik-rs --token ${{ secrets.CRATES_IO_TOKEN }}
 
   release:
     name: GitHub Release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,17 @@
+# Changelog
+
+## 0.8.1 / 0.2.1 - 2026-08-12
+
+- Publish the OxiDNS-maintained facade as `oxidns-mikrotik-rs` 0.8.1.
+- Publish the patched Tokio adapter as `oxidns-mikrotik-tokio` 0.2.1.
+- Replace bounded per-command response channels with unbounded channels so
+  burst replies and terminal events are delivered without loss.
+- Preserve multiplexing responsiveness and receiver-drop cancellation.
+- Document the memory-growth risk for consumers that do not drain long-running
+  streaming responses.
+
+### Compatibility
+
+`MikrotikDevice::send_command` now returns
+`tokio::sync::mpsc::UnboundedReceiver<Event>` instead of
+`tokio::sync::mpsc::Receiver<Event>`.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,11 +4,11 @@ resolver = "3"
 
 [workspace.package]
 edition = "2024"
-authors = ["Alessandro Ferrara"]
+authors = ["Alessandro Ferrara", "Sven"]
 keywords = ["mikrotik", "router", "api", "async", "tokio"]
 license = "AGPL-3.0-only"
 categories = ["api-bindings", "asynchronous", "network-programming"]
-repository = "https://github.com/ferrohd/mikrotik-rs"
+repository = "https://github.com/svenshi/mikrotik-rs"
 
 [workspace.dependencies]
 # Core dependencies
@@ -19,7 +19,7 @@ hashbrown = "0.17"
 
 # Internal crates
 mikrotik-proto = { version = "0.2.0", path = "mikrotik-proto" }
-mikrotik-tokio = { version = "0.2.0", path = "mikrotik-tokio" }
+mikrotik-tokio = { package = "oxidns-mikrotik-tokio", version = "0.2.1", path = "mikrotik-tokio" }
 mikrotik-embassy = { version = "0.1.1", path = "mikrotik-embassy" }
 
 [workspace.lints.rust]

--- a/README.md
+++ b/README.md
@@ -1,10 +1,16 @@
-# mikrotik-rs
+# oxidns-mikrotik-rs
 
-![docs.rs](https://img.shields.io/docsrs/mikrotik-rs)
-![Crates.io](https://img.shields.io/crates/v/mikrotik-rs)
-![Crates.io License](https://img.shields.io/crates/l/mikrotik-rs)
-![Crates.io Total Downloads](https://img.shields.io/crates/d/mikrotik-rs)
-![GitHub Repo stars](https://img.shields.io/github/stars/ferrohd/mikrotik-rs)
+![docs.rs](https://img.shields.io/docsrs/oxidns-mikrotik-rs)
+![Crates.io](https://img.shields.io/crates/v/oxidns-mikrotik-rs)
+![Crates.io License](https://img.shields.io/crates/l/oxidns-mikrotik-rs)
+![Crates.io Total Downloads](https://img.shields.io/crates/d/oxidns-mikrotik-rs)
+![GitHub Repo stars](https://img.shields.io/github/stars/svenshi/mikrotik-rs)
+
+This is an OxiDNS-maintained fork of
+[`mikrotik-rs`](https://github.com/ferrohd/mikrotik-rs). It preserves all
+protocol events during burst traffic by using unbounded per-command channels in
+the Tokio adapter. Consumers of long-running streams must continuously drain or
+drop their receiver to avoid unbounded memory growth.
 
 A Rust client for the [MikroTik RouterOS API](https://help.mikrotik.com/docs/spaces/ROS/pages/47579160/API).
 
@@ -26,8 +32,18 @@ with a type-safe, channel-based API.
 ## Installation
 
 ```bash
-cargo add mikrotik-rs
+cargo add oxidns-mikrotik-rs --rename mikrotik-rs
 ```
+
+OxiDNS keeps the original dependency key so existing `mikrotik_rs` imports do
+not change:
+
+```toml
+mikrotik-rs = { package = "oxidns-mikrotik-rs", version = "0.8.1", optional = true }
+```
+
+This replaces the temporary Git-based `[patch.crates-io]` entries for
+`mikrotik-proto` and `mikrotik-tokio`.
 
 ## Quick start
 
@@ -70,17 +86,17 @@ each one stream responses independently.
 
 ```toml
 # Plaintext (default)
-mikrotik-rs = "0.7"
+mikrotik-rs = { package = "oxidns-mikrotik-rs", version = "0.8.1" }
 
 # TLS for API-SSL (port 8729) — bring your own crypto provider
-mikrotik-rs = { version = "0.7", features = ["tokio-tls"] }
+mikrotik-rs = { package = "oxidns-mikrotik-rs", version = "0.8.1", features = ["tokio-tls"] }
 rustls = { version = "0.23", features = ["ring"] }  # or "aws-lc-rs"
 
 # Embassy embedded adapter (no_std)
-mikrotik-rs = { version = "0.7", default-features = false, features = ["embassy"] }
+mikrotik-rs = { package = "oxidns-mikrotik-rs", version = "0.8.1", default-features = false, features = ["embassy"] }
 
 # Protocol types only (no runtime)
-mikrotik-rs = { version = "0.7", default-features = false }
+mikrotik-rs = { package = "oxidns-mikrotik-rs", version = "0.8.1", default-features = false }
 ```
 
 ## Usage
@@ -218,17 +234,17 @@ The library is split into focused crates:
 
 | Crate | Purpose |
 |---|---|
-| [`mikrotik-proto`](mikrotik-proto/) | Sans-IO protocol core (`#![no_std]`) — wire format, commands, responses, connection state machine |
-| [`mikrotik-tokio`](mikrotik-tokio/) | Tokio async adapter — background actor, per-command channels, TLS |
-| [`mikrotik-embassy`](mikrotik-embassy/) | Embassy embedded async adapter — transport-agnostic over `embedded-io-async` |
-| [`mikrotik-rs`](mikrotik-rs/) | Convenience re-exports from all crates |
+| [`mikrotik-proto`](https://crates.io/crates/mikrotik-proto) | Sans-IO protocol core (`#![no_std]`) — wire format, commands, responses, connection state machine |
+| [`oxidns-mikrotik-tokio`](https://crates.io/crates/oxidns-mikrotik-tokio) | OxiDNS Tokio adapter — lossless per-command channels, background actor, TLS |
+| [`mikrotik-embassy`](https://crates.io/crates/mikrotik-embassy) | Embassy embedded async adapter — transport-agnostic over `embedded-io-async` |
+| [`oxidns-mikrotik-rs`](https://crates.io/crates/oxidns-mikrotik-rs) | Convenience re-exports from all crates |
 
 ```text
 ┌─────────────────────────────────────────────────────────────────┐
-│                        mikrotik-rs                              │
+│                   oxidns-mikrotik-rs                           │
 │                    (re-exports from all)                        │
 ├──────────────────────────┬──────────────────────────────────────┤
-│      mikrotik-tokio      │         mikrotik-embassy             │
+│ oxidns-mikrotik-tokio    │         mikrotik-embassy             │
 │   (Tokio async adapter)  │   (Embassy embedded adapter)         │
 ├──────────────────────────┴──────────────────────────────────────┤
 │                       mikrotik-proto                            │
@@ -238,17 +254,18 @@ The library is split into focused crates:
 
 ## Examples
 
-The repository includes runnable examples in [`examples/`](examples/).
+The repository includes runnable examples in
+[`examples/`](https://github.com/svenshi/mikrotik-rs/tree/v0.8.1/examples).
 
 ## Contributing
 
-Contributions are welcome. Please read [CONTRIBUTING.md](CONTRIBUTING.md) before opening a pull request.
+Contributions are welcome. Please read
+[`CONTRIBUTING.md`](https://github.com/svenshi/mikrotik-rs/blob/v0.8.1/CONTRIBUTING.md)
+before opening a pull request.
 
 ## License
 
-Licensed under the [GNU Affero General Public License v3.0](LICENSE).
-
-For commercial licensing options (use without AGPL obligations), contact the project maintainer.
+Licensed under the GNU Affero General Public License v3.0 (`AGPL-3.0-only`).
 
 ## Disclaimer
 

--- a/examples/check-update/Cargo.toml
+++ b/examples/check-update/Cargo.toml
@@ -10,5 +10,5 @@ repository.workspace = true
 publish = false
 
 [dependencies]
-mikrotik-rs = {package = "mikrotik-rs",  path = "../../mikrotik-rs" }
+mikrotik-rs = { package = "oxidns-mikrotik-rs", path = "../../mikrotik-rs" }
 tokio = { workspace = true, features = ["full"] }

--- a/examples/macro/Cargo.toml
+++ b/examples/macro/Cargo.toml
@@ -10,7 +10,7 @@ repository.workspace = true
 publish = false
 
 [dependencies]
-mikrotik-rs = { package = "mikrotik-rs", path = "../../mikrotik-rs" }
+mikrotik-rs = { package = "oxidns-mikrotik-rs", path = "../../mikrotik-rs" }
 
 [lints]
 workspace = true

--- a/examples/network-monitor/Cargo.toml
+++ b/examples/network-monitor/Cargo.toml
@@ -10,7 +10,7 @@ repository.workspace = true
 publish = false
 
 [dependencies]
-mikrotik-rs = {package = "mikrotik-rs",  path = "../../mikrotik-rs" }
+mikrotik-rs = { package = "oxidns-mikrotik-rs", path = "../../mikrotik-rs" }
 tokio = { workspace = true, features = ["full"] }
 
 [lints]

--- a/examples/system-resource/Cargo.toml
+++ b/examples/system-resource/Cargo.toml
@@ -10,7 +10,7 @@ repository.workspace = true
 publish = false
 
 [dependencies]
-mikrotik-rs = {package = "mikrotik-rs",  path = "../../mikrotik-rs" }
+mikrotik-rs = { package = "oxidns-mikrotik-rs", path = "../../mikrotik-rs" }
 tokio = { workspace = true, features = ["full"] }
 
 [lints]

--- a/examples/users/Cargo.toml
+++ b/examples/users/Cargo.toml
@@ -10,7 +10,7 @@ repository.workspace = true
 publish = false
 
 [dependencies]
-mikrotik-rs = {package = "mikrotik-rs",  path = "../../mikrotik-rs" }
+mikrotik-rs = { package = "oxidns-mikrotik-rs", path = "../../mikrotik-rs" }
 tokio = { workspace = true, features = ["full"] }
 
 [lints]

--- a/mikrotik-embassy/Cargo.toml
+++ b/mikrotik-embassy/Cargo.toml
@@ -6,6 +6,7 @@ edition.workspace = true
 authors.workspace = true
 license.workspace = true
 repository.workspace = true
+publish = false
 
 [lib]
 doctest = false

--- a/mikrotik-embassy/README.md
+++ b/mikrotik-embassy/README.md
@@ -93,4 +93,4 @@ mikrotik_embassy::run(
 
 ## License
 
-Licensed under either of [MIT](../LICENSE-MIT) or [Apache-2.0](../LICENSE-APACHE) at your option.
+Licensed under the GNU Affero General Public License v3.0 (`AGPL-3.0-only`).

--- a/mikrotik-proto/Cargo.toml
+++ b/mikrotik-proto/Cargo.toml
@@ -6,6 +6,7 @@ edition.workspace = true
 authors.workspace = true
 license.workspace = true
 repository.workspace = true
+publish = false
 
 [lib]
 

--- a/mikrotik-proto/README.md
+++ b/mikrotik-proto/README.md
@@ -114,4 +114,4 @@ while let Some(transmit) = hs.poll_transmit() {
 
 ## License
 
-Licensed under either of [MIT](../LICENSE-MIT) or [Apache-2.0](../LICENSE-APACHE) at your option.
+Licensed under the GNU Affero General Public License v3.0 (`AGPL-3.0-only`).

--- a/mikrotik-rs/Cargo.toml
+++ b/mikrotik-rs/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
-name = "mikrotik-rs"
-version = "0.8.0"
-description = "Asynchronous Rust library for interfacing with MikroTik routers"
+name = "oxidns-mikrotik-rs"
+version = "0.8.1"
+description = "OxiDNS-maintained MikroTik RouterOS client with lossless Tokio response delivery"
 edition.workspace = true
 authors.workspace = true
 keywords.workspace = true
@@ -9,9 +9,10 @@ license.workspace = true
 categories.workspace = true
 repository.workspace = true
 readme = "../README.md"
-publish = true
+publish = ["crates-io"]
 
 [lib]
+name = "mikrotik_rs"
 doctest = false
 
 [lints]

--- a/mikrotik-rs/src/lib.rs
+++ b/mikrotik-rs/src/lib.rs
@@ -1,9 +1,9 @@
 #![warn(missing_docs)]
-//! # `MikroTik`-rs
+//! # oxidns-mikrotik-rs
 //!
-//! `mikrotik-rs` is a Rust library for interfacing with `MikroTik` routers via
-//! the `RouterOS` API protocol. It allows sending commands and receiving responses
-//! in parallel through channels.
+//! OxiDNS-maintained fork of `mikrotik-rs`, a Rust library for interfacing with
+//! `MikroTik` routers via the `RouterOS` API protocol. The Tokio adapter uses
+//! lossless per-command response delivery under burst traffic.
 //!
 //! This crate re-exports types from:
 //! - `mikrotik-proto` — sans-IO protocol implementation (always available)
@@ -23,21 +23,21 @@
 //!
 //! ```toml
 //! [dependencies]
-//! mikrotik-rs = { version = "0.7", default-features = false }
+//! mikrotik-rs = { package = "oxidns-mikrotik-rs", version = "0.8.1", default-features = false }
 //! ```
 //!
 //! To use the Embassy adapter instead of Tokio:
 //!
 //! ```toml
 //! [dependencies]
-//! mikrotik-rs = { version = "0.7", default-features = false, features = ["embassy"] }
+//! mikrotik-rs = { package = "oxidns-mikrotik-rs", version = "0.8.1", default-features = false, features = ["embassy"] }
 //! ```
 //!
 //! To enable TLS (e.g., for API-SSL on port 8729):
 //!
 //! ```toml
 //! [dependencies]
-//! mikrotik-rs = { version = "0.7", features = ["tokio-tls"] }
+//! mikrotik-rs = { package = "oxidns-mikrotik-rs", version = "0.8.1", features = ["tokio-tls"] }
 //! rustls = { version = "0.23", features = ["ring"] }  # or "aws-lc-rs"
 //! ```
 //!
@@ -49,14 +49,14 @@
 //!   Handles wire-format encoding/decoding, command building, response parsing,
 //!   and the connection state machine. Performs no I/O.
 //!
-//! - **`mikrotik-tokio`** — Thin async adapter that drives `mikrotik-proto` using
+//! - **`oxidns-mikrotik-tokio`** — Thin async adapter that drives `mikrotik-proto` using
 //!   Tokio's async runtime. Provides the high-level [`MikrotikDevice`] client.
 //!
 //! - **`mikrotik-embassy`** — Embedded async adapter that drives `mikrotik-proto`
 //!   using Embassy's networking stack. Provides a `run` function that the user
 //!   spawns as an Embassy task.
 //!
-//! - **`mikrotik-rs`** (this crate) — Convenience re-exports from all crates.
+//! - **`oxidns-mikrotik-rs`** (this crate) — Convenience re-exports from all crates.
 //!
 //! ## Examples
 //!

--- a/mikrotik-tokio/Cargo.toml
+++ b/mikrotik-tokio/Cargo.toml
@@ -21,7 +21,7 @@ tokio-rustls = { version = "0.26", default-features = false, features = ["tls12"
 rustls = { version = "0.23", default-features = false, features = ["std"], optional = true }
 
 [dev-dependencies]
-tokio = { workspace = true, features = ["net", "sync", "rt", "macros", "io-util", "rt-multi-thread"] }
+tokio = { workspace = true, features = ["net", "sync", "rt", "macros", "io-util", "rt-multi-thread", "time"] }
 
 [lints]
 workspace = true

--- a/mikrotik-tokio/Cargo.toml
+++ b/mikrotik-tokio/Cargo.toml
@@ -1,13 +1,15 @@
 [package]
-name = "mikrotik-tokio"
-description = "Tokio-based async client for MikroTik RouterOS API"
-version = "0.2.0"
+name = "oxidns-mikrotik-tokio"
+description = "OxiDNS-maintained Tokio client for MikroTik RouterOS with lossless response delivery"
+version = "0.2.1"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true
 repository.workspace = true
+publish = ["crates-io"]
 
 [lib]
+name = "mikrotik_tokio"
 doctest = false
 
 [features]

--- a/mikrotik-tokio/README.md
+++ b/mikrotik-tokio/README.md
@@ -46,8 +46,13 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 `MikrotikDevice` is a thin async wrapper around `mikrotik_proto::Connection`:
 
 - **`connect()`** opens a TCP connection, performs the login handshake, and spawns a background actor task.
-- **`send_command()`** sends a command and returns an `mpsc::Receiver<Event>` scoped to that command.
+- **`send_command()`** sends a command and returns an `mpsc::UnboundedReceiver<Event>` scoped to that command.
 - **Drop-based cancellation** — dropping a receiver sends `/cancel` to the router. Dropping all `MikrotikDevice` handles shuts down the connection gracefully.
+
+Response channels are unbounded so queue capacity never drops protocol events
+or blocks unrelated multiplexed commands behind a slow consumer. Long-running
+streaming commands must continuously drain or drop their receiver to avoid
+unbounded memory growth.
 
 ```text
   ┌──────────────────┐   ┌──────────────────┐

--- a/mikrotik-tokio/README.md
+++ b/mikrotik-tokio/README.md
@@ -1,10 +1,17 @@
-# mikrotik-tokio
+# oxidns-mikrotik-tokio
 
-Tokio-based async client for the [MikroTik RouterOS API](https://help.mikrotik.com/docs/spaces/ROS/pages/47579160/API).
+OxiDNS-maintained fork of the Tokio-based async client for the [MikroTik RouterOS API](https://help.mikrotik.com/docs/spaces/ROS/pages/47579160/API).
+
+This fork replaces bounded per-command response channels with unbounded channels,
+preventing reply and terminal events from being silently lost during burst traffic.
 
 This crate provides a high-level async interface built on top of the sans-IO [`mikrotik-proto`](https://crates.io/crates/mikrotik-proto) crate. It drives the protocol state machine using Tokio's async runtime.
 
-**If you just want to talk to a router**, use [`mikrotik-rs`](https://crates.io/crates/mikrotik-rs) instead.
+**If you just want to talk to a router**, use [`oxidns-mikrotik-rs`](https://crates.io/crates/oxidns-mikrotik-rs) instead.
+
+```toml
+mikrotik-tokio = { package = "oxidns-mikrotik-tokio", version = "0.2.1" }
+```
 
 ## Quick start
 
@@ -90,8 +97,8 @@ The actor owns the TCP connection and all protocol logic. Each command gets its 
 
 ## When to use this crate directly
 
-Probably never. `mikrotik-rs` exposes features via feature flags and defaults to `tokio` anyway.
+Probably never. `oxidns-mikrotik-rs` exposes features via feature flags and defaults to `tokio` anyway.
 
 ## License
 
-Licensed under either of [MIT](../LICENSE-MIT) or [Apache-2.0](../LICENSE-APACHE) at your option.
+Licensed under the GNU Affero General Public License v3.0 (`AGPL-3.0-only`).

--- a/mikrotik-tokio/src/device.rs
+++ b/mikrotik-tokio/src/device.rs
@@ -20,7 +20,7 @@ use crate::error::{DeviceError, DeviceResult};
 /// Internal command sent from the [`MikrotikDevice`] handle to the actor task.
 struct DeviceCommand {
     command: Command,
-    respond_to: mpsc::Sender<Event>,
+    respond_to: mpsc::UnboundedSender<Event>,
 }
 
 /// A client for interacting with `MikroTik` devices.
@@ -124,12 +124,23 @@ impl MikrotikDevice {
     /// for this command. This is the idiomatic way to stop a long-running
     /// command — just drop the receiver.
     ///
+    /// # Buffering
+    ///
+    /// Responses use an unbounded channel so protocol events are never dropped
+    /// due to queue capacity and one slow command does not block unrelated
+    /// multiplexed commands. Consumers of long-running streaming commands must
+    /// continuously drain or drop the receiver to prevent unbounded memory
+    /// growth.
+    ///
     /// # Errors
     ///
     /// Returns `DeviceError::Actor(ActorError::CommandSendFailed)` if the
     /// connection actor has shut down.
-    pub async fn send_command(&self, command: Command) -> DeviceResult<mpsc::Receiver<Event>> {
-        let (response_tx, response_rx) = mpsc::channel::<Event>(16);
+    pub async fn send_command(
+        &self,
+        command: Command,
+    ) -> DeviceResult<mpsc::UnboundedReceiver<Event>> {
+        let (response_tx, response_rx) = mpsc::unbounded_channel::<Event>();
 
         self.cmd_tx
             .send(DeviceCommand {
@@ -211,7 +222,7 @@ where
 {
     let (mut rd, mut wr) = tokio::io::split(stream);
     let mut buf = vec![0u8; 8192];
-    let mut response_map: HashMap<Tag, mpsc::Sender<Event>> = HashMap::new();
+    let mut response_map: HashMap<Tag, mpsc::UnboundedSender<Event>> = HashMap::new();
     let mut shutdown = false;
 
     while !shutdown {
@@ -279,7 +290,7 @@ where
 
 /// Route a protocol event to the appropriate per-command channel.
 fn route_event(
-    response_map: &mut HashMap<Tag, mpsc::Sender<Event>>,
+    response_map: &mut HashMap<Tag, mpsc::UnboundedSender<Event>>,
     conn: &mut Connection,
     event: Event,
 ) {
@@ -287,7 +298,7 @@ fn route_event(
         Event::Reply { tag, .. } => {
             let tag = *tag;
             if let Some(sender) = response_map.get(&tag)
-                && sender.try_send(event).is_err()
+                && sender.send(event).is_err()
             {
                 response_map.remove(&tag);
                 let _ = conn.cancel_command(tag);
@@ -296,12 +307,12 @@ fn route_event(
         Event::Done { tag } | Event::Empty { tag } | Event::Trap { tag, .. } => {
             let tag = *tag;
             if let Some(sender) = response_map.remove(&tag) {
-                let _ = sender.try_send(event);
+                let _ = sender.send(event);
             }
         }
         Event::Fatal { .. } => {
             for (_, sender) in response_map.drain() {
-                let _ = sender.try_send(event.clone());
+                let _ = sender.send(event.clone());
             }
         }
     }

--- a/mikrotik-tokio/src/lib.rs
+++ b/mikrotik-tokio/src/lib.rs
@@ -1,7 +1,9 @@
 #![warn(missing_docs)]
-//! # mikrotik-tokio
+//! # oxidns-mikrotik-tokio
 //!
-//! Tokio-based async client for `MikroTik` `RouterOS` API.
+//! OxiDNS-maintained fork of the Tokio-based async client for the `MikroTik`
+//! `RouterOS` API. It uses unbounded per-command response channels so burst
+//! traffic cannot silently discard protocol events.
 //!
 //! This crate provides a high-level async interface built on top of the
 //! sans-IO [`mikrotik_proto`] crate. It drives the protocol state machine
@@ -17,7 +19,7 @@
 //! crypto backend to your dependencies:
 //!
 //! ```toml
-//! mikrotik-tokio = { version = "0.1", features = ["tokio-tls"] }
+//! mikrotik-tokio = { package = "oxidns-mikrotik-tokio", version = "0.2.1", features = ["tokio-tls"] }
 //! rustls = { version = "0.23", features = ["ring"] }  # or "aws-lc-rs"
 //! ```
 

--- a/mikrotik-tokio/tests/device.rs
+++ b/mikrotik-tokio/tests/device.rs
@@ -10,6 +10,8 @@ use mikrotik_proto::connection::Event;
 use mikrotik_tokio::MikrotikDevice;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::TcpListener;
+use tokio::sync::{mpsc, oneshot};
+use tokio::time::{Duration, timeout};
 
 // ── Wire-format helpers (simulate what a router sends) ──
 
@@ -115,6 +117,54 @@ async fn mock_listener() -> (TcpListener, String) {
     (listener, addr)
 }
 
+fn encode_numbered_replies(tag: &str, count: usize) -> Vec<u8> {
+    let mut data = Vec::new();
+    for index in 0..count {
+        let value = index.to_string();
+        data.extend_from_slice(&encode_reply(tag, &[("sequence", &value)]));
+    }
+    data
+}
+
+async fn wait_for_queued_events(rx: &mpsc::UnboundedReceiver<Event>, expected: usize) {
+    timeout(Duration::from_secs(1), async {
+        while rx.len() < expected {
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .expect("expected events were not queued in time");
+}
+
+async fn receive_exact(rx: &mut mpsc::UnboundedReceiver<Event>, count: usize) -> Vec<Event> {
+    timeout(Duration::from_secs(1), async {
+        let mut events = Vec::with_capacity(count);
+        for _ in 0..count {
+            events.push(rx.recv().await.expect("response channel closed early"));
+        }
+        events
+    })
+    .await
+    .expect("timed out receiving command events")
+}
+
+fn assert_numbered_replies_then_done(events: &[Event], reply_count: usize) {
+    assert_eq!(events.len(), reply_count + 1, "events: {events:?}");
+
+    for (index, event) in events[..reply_count].iter().enumerate() {
+        match event {
+            Event::Reply { response, .. } => assert_eq!(
+                response.attributes.get("sequence"),
+                Some(&Some(index.to_string())),
+                "reply {index} was reordered or lost"
+            ),
+            other => panic!("expected Reply at index {index}, got {other:?}"),
+        }
+    }
+
+    assert!(matches!(events.last(), Some(Event::Done { .. })));
+}
+
 // ── Tests ──
 
 #[tokio::test]
@@ -198,6 +248,106 @@ async fn send_command_receive_reply() {
     assert!(rx.recv().await.is_none());
 
     mock.await.unwrap();
+}
+
+async fn assert_unbounded_reply_burst(reply_count: usize) {
+    let (listener, addr) = mock_listener().await;
+    let (release_mock_tx, release_mock_rx) = oneshot::channel();
+
+    let mock = tokio::spawn(async move {
+        let (stream, _) = listener.accept().await.unwrap();
+        let mut mock = MockStream::new(stream);
+
+        let words = mock.read_sentence().await;
+        let login_tag = extract_tag(&words);
+        mock.write_all(&encode_done(&login_tag)).await;
+
+        let words = mock.read_sentence().await;
+        let command_tag = extract_tag(&words);
+
+        let mut response = encode_numbered_replies(&command_tag, reply_count);
+        response.extend_from_slice(&encode_done(&command_tag));
+        mock.write_all(&response).await;
+
+        tokio::select! {
+            biased;
+            words = mock.read_sentence() => Some(words),
+            _ = release_mock_rx => None,
+        }
+    });
+
+    let device = MikrotikDevice::connect(&addr, "admin", Some("password"))
+        .await
+        .unwrap();
+    let command = CommandBuilder::new().command("/interface/print").build();
+    let mut rx = device.send_command(command).await.unwrap();
+
+    // Do not consume until the complete burst, including Done, has been queued.
+    wait_for_queued_events(&rx, reply_count + 1).await;
+    let events = receive_exact(&mut rx, reply_count + 1).await;
+
+    release_mock_tx.send(()).unwrap();
+    let unexpected_outbound = mock.await.unwrap();
+    assert!(
+        unexpected_outbound.is_none(),
+        "command was unexpectedly cancelled: {unexpected_outbound:?}"
+    );
+    assert_numbered_replies_then_done(&events, reply_count);
+    assert!(rx.recv().await.is_none());
+}
+
+#[tokio::test]
+async fn reply_burst_larger_than_previous_capacity_is_delivered() {
+    assert_unbounded_reply_burst(40).await;
+}
+
+#[tokio::test]
+async fn done_is_delivered_after_exactly_sixteen_replies() {
+    assert_unbounded_reply_burst(16).await;
+}
+
+#[tokio::test]
+async fn dropping_response_receiver_cancels_command_on_next_reply() {
+    let (listener, addr) = mock_listener().await;
+    let (command_seen_tx, command_seen_rx) = oneshot::channel();
+    let (receiver_dropped_tx, receiver_dropped_rx) = oneshot::channel();
+
+    let mock = tokio::spawn(async move {
+        let (stream, _) = listener.accept().await.unwrap();
+        let mut mock = MockStream::new(stream);
+
+        let words = mock.read_sentence().await;
+        let login_tag = extract_tag(&words);
+        mock.write_all(&encode_done(&login_tag)).await;
+
+        let words = mock.read_sentence().await;
+        let command_tag = extract_tag(&words);
+        command_seen_tx.send(()).unwrap();
+
+        receiver_dropped_rx.await.unwrap();
+        mock.write_all(&encode_reply(&command_tag, &[("value", "late")]))
+            .await;
+
+        let cancel = mock.read_sentence().await;
+        assert_eq!(cancel[0], "/cancel");
+        assert_eq!(extract_tag(&cancel), command_tag);
+        assert!(cancel.contains(&format!("=tag={command_tag}")));
+    });
+
+    let device = MikrotikDevice::connect(&addr, "admin", Some("password"))
+        .await
+        .unwrap();
+    let command = CommandBuilder::new().command("/tool/torch").build();
+    let rx = device.send_command(command).await.unwrap();
+
+    command_seen_rx.await.unwrap();
+    drop(rx);
+    receiver_dropped_tx.send(()).unwrap();
+
+    timeout(Duration::from_secs(1), mock)
+        .await
+        .expect("mock did not receive /cancel")
+        .unwrap();
 }
 
 #[tokio::test]
@@ -305,7 +455,7 @@ async fn concurrent_commands() {
     // Each receiver should get its own reply + done (responses arrive in reverse)
     // But each channel only receives events for its own tag.
     // Collect until we see a terminal event (Done).
-    async fn collect_until_done(rx: &mut tokio::sync::mpsc::Receiver<Event>) -> Vec<Event> {
+    async fn collect_until_done(rx: &mut mpsc::UnboundedReceiver<Event>) -> Vec<Event> {
         let mut events = Vec::new();
         while let Some(event) = rx.recv().await {
             let is_terminal = matches!(&event, Event::Done { .. } | Event::Empty { .. });
@@ -332,6 +482,62 @@ async fn concurrent_commands() {
     assert!(matches!(&e1[1], Event::Done { .. }));
 
     mock.await.unwrap();
+}
+
+#[tokio::test]
+async fn slow_consumer_does_not_block_multiplexed_command() {
+    let (listener, addr) = mock_listener().await;
+    let (release_mock_tx, release_mock_rx) = oneshot::channel();
+
+    let mock = tokio::spawn(async move {
+        let (stream, _) = listener.accept().await.unwrap();
+        let mut mock = MockStream::new(stream);
+
+        let words = mock.read_sentence().await;
+        let login_tag = extract_tag(&words);
+        mock.write_all(&encode_done(&login_tag)).await;
+
+        let first = mock.read_sentence().await;
+        let first_tag = extract_tag(&first);
+        let second = mock.read_sentence().await;
+        let second_tag = extract_tag(&second);
+
+        let mut response = encode_numbered_replies(&first_tag, 40);
+        response.extend_from_slice(&encode_reply(&second_tag, &[("value", "second")]));
+        response.extend_from_slice(&encode_done(&second_tag));
+        response.extend_from_slice(&encode_done(&first_tag));
+        mock.write_all(&response).await;
+
+        tokio::select! {
+            biased;
+            words = mock.read_sentence() => Some(words),
+            _ = release_mock_rx => None,
+        }
+    });
+
+    let device = MikrotikDevice::connect(&addr, "admin", Some("password"))
+        .await
+        .unwrap();
+    let first = CommandBuilder::new().command("/slow").build();
+    let second = CommandBuilder::new().command("/fast").build();
+    let mut first_rx = device.send_command(first).await.unwrap();
+    let mut second_rx = device.send_command(second).await.unwrap();
+
+    // Consume the second command first while all first-command events remain queued.
+    let second_events = receive_exact(&mut second_rx, 2).await;
+    assert!(matches!(second_events[0], Event::Reply { .. }));
+    assert!(matches!(second_events[1], Event::Done { .. }));
+
+    wait_for_queued_events(&first_rx, 41).await;
+    let first_events = receive_exact(&mut first_rx, 41).await;
+
+    release_mock_tx.send(()).unwrap();
+    let unexpected_outbound = mock.await.unwrap();
+    assert!(
+        unexpected_outbound.is_none(),
+        "slow command was unexpectedly cancelled: {unexpected_outbound:?}"
+    );
+    assert_numbered_replies_then_done(&first_events, 40);
 }
 
 #[tokio::test]
@@ -396,12 +602,16 @@ async fn fatal_error_propagates_to_all_receivers() {
         mock.write_all(&encode_done(&login_tag)).await;
 
         // Read 2 commands
-        let _words1 = mock.read_sentence().await;
+        let words1 = mock.read_sentence().await;
+        let first_tag = extract_tag(&words1);
         let _words2 = mock.read_sentence().await;
 
-        // Send a fatal error — no need to keep the connection alive,
-        // the bytes are in the TCP buffer.
-        mock.write_all(&encode_fatal("out of memory")).await;
+        // Queue a large reply burst for the first command, then terminate the
+        // entire connection. The second command must still receive Fatal even
+        // while the first receiver is not being consumed.
+        let mut response = encode_numbered_replies(&first_tag, 40);
+        response.extend_from_slice(&encode_fatal("out of memory"));
+        mock.write_all(&response).await;
     });
 
     let device = MikrotikDevice::connect(&addr, "admin", Some("pass"))
@@ -413,26 +623,25 @@ async fn fatal_error_propagates_to_all_receivers() {
     let mut rx1 = device.send_command(cmd1).await.unwrap();
     let mut rx2 = device.send_command(cmd2).await.unwrap();
 
-    // After the actor processes !fatal:
-    //   1. route_event drains response_map → sends Fatal to both Senders → drops them
-    //   2. Actor sees conn is dead → shutdown = true → exits → final cleanup
-    //   3. Both receivers get Some(Fatal) then None (channel closed)
-    let mut got_fatal_1 = false;
-    while let Some(event) = rx1.recv().await {
-        if matches!(event, Event::Fatal { .. }) {
-            got_fatal_1 = true;
+    // Consume the second receiver first to verify one backlogged command does
+    // not delay fatal notification for another active command.
+    let second_events = receive_exact(&mut rx2, 1).await;
+    assert!(matches!(second_events[0], Event::Fatal { .. }));
+    assert!(rx2.recv().await.is_none());
+
+    wait_for_queued_events(&rx1, 41).await;
+    let first_events = receive_exact(&mut rx1, 41).await;
+    for (index, event) in first_events[..40].iter().enumerate() {
+        match event {
+            Event::Reply { response, .. } => assert_eq!(
+                response.attributes.get("sequence"),
+                Some(&Some(index.to_string()))
+            ),
+            other => panic!("expected Reply at index {index}, got {other:?}"),
         }
     }
-
-    let mut got_fatal_2 = false;
-    while let Some(event) = rx2.recv().await {
-        if matches!(event, Event::Fatal { .. }) {
-            got_fatal_2 = true;
-        }
-    }
-
-    assert!(got_fatal_1, "rx1 should receive Fatal event");
-    assert!(got_fatal_2, "rx2 should receive Fatal event");
+    assert!(matches!(first_events.last(), Some(Event::Fatal { .. })));
+    assert!(rx1.recv().await.is_none());
 
     mock.await.unwrap();
 }


### PR DESCRIPTION
- Use unbounded per-command channels to preserve reply and terminal ordering.
- Keep multiplexed commands responsive while retaining receiver-drop cancellation.
- Add regression coverage for bursts, terminal delivery, cancellation, fatal events, and slow consumers.
- Document the memory implications for long-running streaming commands.

BREAKING CHANGE: `MikrotikDevice::send_command` now returns `mpsc::UnboundedReceiver<Event>` instead of `mpsc::Receiver<Event>`.

## Summary

This PR replaces `mikrotik-tokio`'s bounded per-command response channels with
unbounded channels, preventing valid replies and terminal events from being
dropped during burst traffic.

This patch is currently used by OxiDNS. I am submitting it upstream as a
pragmatic solution for consideration; the maintainers can decide whether the
unbounded-channel trade-off is appropriate for the general-purpose client.

## Motivation

`MikrotikDevice::send_command` currently creates a response channel with a
capacity of 16. `route_event` forwards responses using `try_send`, but treats
every send failure as if the receiver had been dropped.

When RouterOS produces responses faster than the consumer is scheduled,
`TrySendError::Full` causes the client to remove the command and send `/cancel`,
even though the receiver is still alive.

Terminal events are also sent with `try_send` while errors are ignored. For
example, exactly 16 replies followed by `!done` can fill the channel and
silently lose the `Done` event.

## Changes

- Replace per-command bounded response channels with
  `mpsc::unbounded_channel`.
- Cancel commands only when response delivery fails because the receiver is
  closed.
- Preserve FIFO delivery of replies and terminal events.
- Keep unrelated multiplexed commands responsive when one consumer is slow.
- Document the memory implications of unbounded response buffering.
- Add regression coverage for:
  - 40 replies followed by `Done`
  - exactly 16 replies followed by `Done`
  - receiver-drop cancellation
  - slow consumers with multiplexed commands
  - fatal events after queued replies

## Trade-offs

This changes the public return type of `MikrotikDevice::send_command` from:

```rust
mpsc::Receiver<Event>
```

to:

```rust
mpsc::UnboundedReceiver<Event>
```

Most callers using `recv().await` remain source-compatible, but explicit
receiver type annotations must be updated.

The response queue can grow without a fixed bound if a consumer stops reading a
long-running streaming command. Such consumers must continuously drain or drop
the receiver. The actor's command submission channel remains bounded.

## Checklist

- [x] Code compiles without warnings (`cargo build --workspace`)
- [x] Tests pass (`cargo test --workspace`)
- [x] Lints pass (`cargo clippy --workspace`)
- [x] Documentation updated (if applicable)
- [x] I agree to the [Contributor License Agreement](../CONTRIBUTING.md#contributor-license-agreement)